### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/hashansilva/BibleMate/security/code-scanning/1](https://github.com/hashansilva/BibleMate/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Since the workflow primarily checks out code and builds it, it only needs `contents: read` permissions. This change will ensure that the workflow does not have unnecessary write access to the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
