### PR TITLE
Run CI on dev and master branches

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -2,9 +2,9 @@ name: Android CI
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "dev" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "dev" ]
 
 permissions:
   contents: read

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,9 +30,9 @@ name: SonarCloud analysis
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "dev" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "master", "dev" ]
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -155,7 +155,9 @@ Key dependencies include:
 
 ## Code Quality
 
-Pull requests trigger a [SonarCloud](https://sonarcloud.io) analysis. Configure the `SONAR_TOKEN` secret in your repository to enable the workflow.
+Pushes and pull requests to the **dev** and **master** branches trigger a
+[SonarCloud](https://sonarcloud.io) analysis. Configure the `SONAR_TOKEN`
+secret in your repository to enable the workflow.
 
 ---
 


### PR DESCRIPTION
## Summary
- run Android build CI on `dev` and `master`
- run SonarCloud analysis on both branches
- document the new quality checks policy

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_b_685b022489608324b6f54bb5903625f4